### PR TITLE
add upx as post run

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,9 @@ builds:
       - 6
       - 7
     mod_timestamp: '{{ .CommitTimestamp }}'
+    hooks:
+      post:
+       - upx -v --no-progress --lzma "{{ .Path }}"
 archives:
   - id: gopass
     name_template: "{{.Binary}}-{{.Version}}-{{.Os}}-{{.Arch}}{{ if .Arm }}v{{.Arm }}{{ end }}"


### PR DESCRIPTION
the upx reduce the file size about 70%
form 15MB to 4,4MB

```shell
$ upx -vvv --lzma gopass
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2020
UPX 3.96        Markus Oberhumer, Laszlo Molnar & John Reiser   Jan 23rd 2020

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  14741504 ->   4575504   31.04%   linux/amd64   gopass

Packed 1 file.
$ ./gopass version
gopass 1.15.3 go1.19.4 linux amd64
$ 
```

Signed-off-by: berlin4apk <83521068+berlin4apk@users.noreply.github.com>